### PR TITLE
Adding the first user story issue and the waffle link

### DIFF
--- a/projects/gitrank.md
+++ b/projects/gitrank.md
@@ -14,4 +14,10 @@ There are some services that are emerging around this market like [StackShare](h
 ## Team
 [Brunno Attorre](../people/brunno-attorre.md), [Karan Bir](../people/karan-bir.md), [Nicolas Joseph](../people/nicolas-joseph.md)
 
+## First user Story
+Our first user story can be found on: [Issue #53](https://github.com/gitlinks/gitrank-web/issues/53)
+
+## Project Management
+We are using Waffle as our project management tool. You can get a view about issues and features being added on the project. [Waffle](https://waffle.io/gitlinks/gitrank-web) 
+
 **Extensive information about the project can be found [here](https://github.com/gitlinks/github-rank-project)**


### PR DESCRIPTION
Adding the link to the first user story issue and the link to our issue management tool (waffle).
