### PR TITLE
Project first story for game master

### DIFF
--- a/projects/game-master.md
+++ b/projects/game-master.md
@@ -13,3 +13,7 @@ We will record, with users' permission, the final result and possible data as mu
 ### Team
 
 [Thomas Yang](/people/thomas-yang.md), [Ming Chen](/people/ming-chen.md), [Matt Zhang](/people/matt-zhang.md)
+
+### Product Management
+
+https://trello.com/b/XGlWnY5g/product


### PR DESCRIPTION
Remove the first story from project page. It's in the trello board now.

Signed-off-by: velicue mc2543@cornell.edu
